### PR TITLE
Optimize the calculation of Euclidean distance for 1-dimensional data.

### DIFF
--- a/kmeans.cpp
+++ b/kmeans.cpp
@@ -132,31 +132,38 @@ private:
     {
         double sum = 0.0, min_dist;
         int NearestClusterId;
-
-        for (int i = 0; i < dimensions; i++)
+        if(dimensions==1) {
+            min_dist = clusters[0].getCentroidByPos(0) - point.getVal(0);
+        }	
+        else 
         {
-            sum += pow(clusters[0].getCentroidByPos(i) - point.getVal(i), 2.0);
-            // sum += abs(clusters[0].getCentroidByPos(i) - point.getVal(i));
+          for (int i = 0; i < dimensions; i++)
+          {
+             sum += pow(clusters[0].getCentroidByPos(i) - point.getVal(i), 2.0);
+             // sum += abs(clusters[0].getCentroidByPos(i) - point.getVal(i));
+          }
+          min_dist = sqrt(sum);
         }
-
-        min_dist = sqrt(sum);
-        // min_dist = sum;
         NearestClusterId = clusters[0].getId();
 
         for (int i = 1; i < K; i++)
         {
             double dist;
             sum = 0.0;
+            
+            if(dimensions==1) {
+                  sum = clusters[i].getCentroidByPos(0) - point.getVal(0);
+            } 
+            else {
+              for (int j = 0; j < dimensions; j++)
+              {
+                  sum += pow(clusters[i].getCentroidByPos(j) - point.getVal(j), 2.0);
+                  // sum += abs(clusters[i].getCentroidByPos(j) - point.getVal(j));
+              }
 
-            for (int j = 0; j < dimensions; j++)
-            {
-                sum += pow(clusters[i].getCentroidByPos(j) - point.getVal(j), 2.0);
-                // sum += abs(clusters[i].getCentroidByPos(j) - point.getVal(j));
+              dist = sqrt(sum);
+              // dist = sum;
             }
-
-            dist = sqrt(sum);
-            // dist = sum;
-
             if (dist < min_dist)
             {
                 min_dist = dist;


### PR DESCRIPTION
When we're handling one dimensional data, the calculation of Euclidean distance is just a subtraction, so we can avoid the pow and sqrt operations.